### PR TITLE
Ensure that the MySQL connection pool isn't maxed out

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,6 +3,14 @@ require 'sinatra/base'
 require 'sinatra/json'
 
 class App < Sinatra::Base
+  DB = Sequel.connect(
+    adapter: 'mysql2',
+    host: ENV.fetch('DB_HOSTNAME'),
+    database: ENV.fetch('DB_NAME'),
+    user: ENV.fetch('DB_USER'),
+    password: ENV.fetch('DB_PASS')
+  )
+
   get '/authorize/user/:user_name' do
     authorize_user(params['user_name'])
   end
@@ -19,18 +27,7 @@ private
     json "control:Cleartext-Password": user[:password]
   end
 
-  def connect_to_db
-    Sequel.connect(
-      adapter: 'mysql2',
-      host: ENV.fetch('DB_HOSTNAME'),
-      database: ENV.fetch('DB_NAME'),
-      user: ENV.fetch('DB_USER'),
-      password: ENV.fetch('DB_PASS')
-    )
-  end
-
   def user_from_db(user_name)
-    db = connect_to_db
-    db[:userdetails].select(Sequel[:password]).first(username: user_name)
+    DB[:userdetails].select(Sequel[:password]).first(username: user_name)
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe App do
           get url
         end
 
-        it 'responds with password in the body', focus: true do
+        it 'responds with password in the body' do
           expect(last_response.body).to eq('{"control:Cleartext-Password":"FooBarBaz"}')
         end
       end
@@ -71,6 +71,22 @@ RSpec.describe App do
         it 'responds with an empty string' do
           expect(last_response.body).to eq('')
         end
+      end
+    end
+
+    context 'with multiple connections to mysql' do
+      let(:url) { "/authorize/user/#{username}" }
+
+      before do
+        db[:userdetails].insert(username: username, password: 'FooBarBaz')
+
+        200.times do
+          get url
+        end
+      end
+
+      it 'does not fall over' do
+        expect(last_response).to be_ok
       end
     end
   end


### PR DESCRIPTION
Currently the nature of how we connect to the database is causing the
MySQL connection pool to be exhausted. By initializing the connection as
a constant we an avoid establishing new connections while it remains in
memory.