### PR TITLE
Listen on 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,4 @@ RUN apk --update --upgrade add build-base mysql-dev && \
 
 COPY . .
 
-
-CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "9080"]
+CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,4 @@ services:
     links:
       - db
     ports:
-      - "9080:9080"
+      - "8080:8080"


### PR DESCRIPTION
The way we are setting up ECS with the Application Loadbalancer means we
don't have to keep using unique ports.

Existing security groups allow traffic on 8080, so use that instead of defining new security groups