### PR TITLE
WIP: Use a more configurable logging solution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk --update --upgrade add build-base mysql-dev && \
 
 COPY . .
 
-CMD ["bundle", "exec", "rackup", "-o", "0.0.0.0", "-p", "8080"]
+CMD ["bundle", "exec", "rackup", "-q", "-o", "0.0.0.0", "-p", "8080"]

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby File.read('.ruby-version').chomp
 
 gem 'mysql2'
 gem 'puma'
+gem 'semantic_logger'
 gem 'sentry-raven'
 gem 'sequel', '~> 5.9'
 gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     ast (2.4.0)
     backports (2.8.2)
+    concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
@@ -61,6 +62,8 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    semantic_logger (4.3.0)
+      concurrent-ruby (~> 1.0)
     sentry-raven (2.7.3)
       faraday (>= 0.7.6, < 1.0)
     sequel (5.9.0)
@@ -88,6 +91,7 @@ DEPENDENCIES
   puma
   rack-test
   rspec
+  semantic_logger
   sentry-raven
   sequel (~> 5.9)
   sinatra
@@ -97,4 +101,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/app.rb
+++ b/app.rb
@@ -1,10 +1,63 @@
 require 'sequel'
 require 'sinatra/base'
 require 'sinatra/json'
+require 'semantic_logger'
+
+class SemanticLoggerMiddleware
+  def initialize(app, logger: nil)
+    @app = app
+    @logger = logger
+  end
+
+  def call(env)
+    env['rack.logger'] = @logger
+    env['Request-ID'] ||= SecureRandom.hex(8)
+
+    @logger.tagged(request_id: env['Request-ID']) do
+      log_start(env)
+      @app.call(env).tap do |status, headers, _body|
+        log_end(env, status, headers)
+      end
+    end
+  end
+
+  private
+
+  def log_start(env)
+    @logger.info(
+      'Request started',
+      address: env['HTTP_X_FORWARDED_FOR'] || env["REMOTE_ADDR"] || "-",
+      user: env["REMOTE_USER"] || "-",
+      time: Time.now.strftime("%d/%b/%Y:%H:%M:%S %z"),
+      method: env['REQUEST_METHOD'],
+      path: env['PATH_INFO'],
+      query: env['QUERY_STRING'],
+      http_version: env['HTTP_VERSION'],
+    )
+  end
+
+  def log_end(env, status, headers)
+    @logger.info(
+      'Request finished',
+      status: status.to_s[0..3],
+      length: headers['Content-Length'] || '-',
+    )
+  end
+end
+
 
 class App < Sinatra::Base
-  configure :production, :staging, :development do
-    enable :logging
+  set :logger, SemanticLogger[App]
+
+  configure do
+    SemanticLogger.default_level = :debug
+    SemanticLogger.add_appender(io: STDOUT, formatter: :color)
+
+    use SemanticLoggerMiddleware, logger: logger
+  end
+
+  configure :production do
+    SemanticLogger.default_level = :info
   end
 
   DB = Sequel.connect(


### PR DESCRIPTION
- enables tagging logs in contexts
- allows for structured outputs

TODO:
This should really be a separate package, where the tags are configurable.

before:
```
TODO: Fill this in
```

After:
```
app_1  | 2018-10-23 15:27:19.454704 I [1:puma 001] {request_id: f17dbcf3a04ce5c6} App -- Request started -- {:address=>"192.168.16.1", :user=>"-", :time=>"23/Oct/2018:15:27:19 +0000", :method=>"GET", :path=>"/", :query=>"", :http_version=>"HTTP/1.1"}
app_1  | 2018-10-23 15:27:19.455157 I [1:puma 001] {request_id: f17dbcf3a04ce5c6} App -- Within a controller
app_1  | 2018-10-23 15:27:19.465314 I [1:puma 001] {request_id: f17dbcf3a04ce5c6} App -- Request finished -- {:status=>"200", :length=>"12"}
```