### PR TITLE
don't output stacktraces to the logs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,10 @@ class App < Sinatra::Base
     enable :logging
   end
 
+  configure :production, :staging do
+    set :dump_errors, false
+  end
+
   DB = Sequel.connect(
     adapter: 'mysql2',
     host: ENV.fetch('DB_HOSTNAME'),


### PR DESCRIPTION
Causes clutter in the logs, and we have sentry for this