### PR TITLE
break out deploy check into its own stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -110,24 +110,7 @@ def deploy_production() {
   if(deployCancelled()) {
     return
   }
-
-  try {
-    timeout(time: 5, unit: 'MINUTES') {
-      input "Do you want to deploy to production?"
-
-      deploy('production')
-    }
-  } catch(err) { // timeout reached or input false
-    def user = err.getCauses()[0].getUser()
-
-    if('SYSTEM' == user.toString()) { // SYSTEM means timeout.
-      Globals.didTimeout = true
-      echo "Release window timed out, to deploy please re-run"
-    } else {
-      Globals.userInput = false
-      echo "Aborted by: [${user}]"
-    }
-  }
+  deploy('production')
 }
 
 def deploy(deploy_environment) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,34 +50,10 @@ pipeline {
   }
 
   post {
-    failure {
-      script {
-        if(deployCancelled()) {
-          setBuildStatus("Build successful", "SUCCESS");
-          return
-        }
-      }
-      setBuildStatus("Build failed", "FAILURE");
-    }
-
-    success {
-      setBuildStatus("Build successful", "SUCCESS");
-    }
-
     cleanup {
       sh 'make stop'
     }
   }
-}
-
-void setBuildStatus(String message, String state) {
-  step([
-      $class: "GitHubCommitStatusSetter",
-      reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/alphagov/govwifi-authentication-api"],
-      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
-      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
-      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
-  ]);
 }
 
 def deploy_staging() {
@@ -86,7 +62,6 @@ def deploy_staging() {
 
 def deploy_production() {
   if(deployCancelled()) {
-    setBuildStatus("Build successful", "SUCCESS");
     return
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,23 +4,38 @@ class Globals {
 }
 
 pipeline {
-  agent any
+  agent none
   stages {
     stage('Linting') {
+      agent any
       steps {
         sh 'make lint'
+      }
+      post {
+        always {
+          sh 'make stop'
+        }
       }
     }
 
     stage('Test') {
+      agent any
       steps {
         sh 'make test'
       }
+      post {
+        always {
+          sh 'make stop'
+        }
+      }
+
     }
 
     stage('Publish stable tag') {
-      when{
+      agent any
+      when {
         branch 'master'
+        beforeAgent true
       }
 
       steps {
@@ -29,8 +44,10 @@ pipeline {
     }
 
     stage('Deploy to staging') {
+      agent any
       when{
         branch 'master'
+        beforeAgent true
       }
 
       steps {
@@ -39,19 +56,15 @@ pipeline {
     }
 
     stage('Deploy to production') {
-      when{
+      agent any
+      when {
         branch 'master'
+        beforeAgent true
       }
 
       steps {
         deploy_production()
       }
-    }
-  }
-
-  post {
-    cleanup {
-      sh 'make stop'
     }
   }
 }


### PR DESCRIPTION
this enables us to run it agentless, so we don't block an executor

Also remove explicit github notifications, as this is handled by multi-branch builds already