### PR TITLE
Add sensible_logging gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby File.read('.ruby-version').chomp
 
 gem 'mysql2'
 gem 'puma'
+gem 'sensible_logging', '~> 0.3.0'
 gem 'sentry-raven'
 gem 'sequel', '~> 5.14'
 gem 'sinatra'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby File.read('.ruby-version').chomp
 
 gem 'mysql2'
 gem 'puma'
-gem 'sensible_logging', '~> 0.3.0'
+gem 'sensible_logging', '~> 0.4.0'
 gem 'sentry-raven'
 gem 'sequel', '~> 5.14'
 gem 'sinatra'

--- a/app.rb
+++ b/app.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+require 'sensible_logging'
 require 'sequel'
 require 'sinatra/base'
 require 'sinatra/json'
@@ -5,12 +8,18 @@ require 'logger'
 
 
 class App < Sinatra::Base
+  register Sinatra::SensibleLogging
+
+  sensible_logging(
+    logger: Logger.new(STDOUT)
+  )
+
   configure do
-    enable :logging
-    set :logging, Logger::DEBUG
+    set :log_level, Logger::DEBUG
   end
+
   configure :production do
-    set :logging, Logger::INFO
+    set :log_level, Logger::INFO
   end
 
   configure :production, :staging do

--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'sensible_logging'
 require 'sequel'
 require 'sinatra/base'

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,6 @@
+#\ --quiet
+# The above is needed to prevent rack from request logging
+
 RACK_ENV = ENV['RACK_ENV'] ||= 'development' unless defined?(RACK_ENV)
 
 if %w[production staging].include?(RACK_ENV)


### PR DESCRIPTION
Sets up [sensible_logging](https://github.com/madetech/sensible_logging) gem which provides:

* Tagged logging
* Request ID (for tagged logging, and to include in Sentry exceptions in future)
* Minimal request log format

Example output from request logging:

```
[localhost] [development] [76b706bf-7f0c-48ec-8045-57a40d5aad82] method=GET path=/healthcheck status=200 duration=0.0207032 params={"test"=>"one", "two"=>"three"}
```

If you reference the built in Sinatra `logger` helper within the app/routes, then you'll see output like:

```
get 'healthcheck' do
  logger.debug('testing')
  'Healthcheck'
end
```

```
[localhost] [development] [76b706bf-7f0c-48ec-8045-57a40d5aad82] testing
[localhost] [development] [76b706bf-7f0c-48ec-8045-57a40d5aad82] method=GET path=/healthcheck status=200 duration=0.0207032 params={"test"=>"one", "two"=>"three"}
```