### PR TITLE
Remove extra debugging for auth API

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -50,7 +50,6 @@ private
   end
 
   def user_from_db(user_name)
-    logger.info("we are executing a database query - #{Time.now.to_i}")
     DB[:userdetails].select(Sequel[:password]).first(username: user_name)
   end
 end


### PR DESCRIPTION
We understand that extra API calls are happening here, while we don't
have a solid fix yet, we don't need to print debug output