### PR TITLE
Move dependencies to loader

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby File.read('.ruby-version').chomp
 
 gem 'mysql2'
 gem 'puma'
+gem 'require_all'
 gem 'sensible_logging', '~> 0.4.0'
 gem 'sentry-raven'
 gem 'sequel', '~> 5.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    require_all (2.0.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -111,6 +112,7 @@ DEPENDENCIES
   mysql2
   puma
   rack-test
+  require_all
   rspec
   sensible_logging (~> 0.4.0)
   sentry-raven

--- a/app.rb
+++ b/app.rb
@@ -1,9 +1,4 @@
-require 'sensible_logging'
-require 'sequel'
-require 'sinatra/base'
-require 'sinatra/json'
-require 'logger'
-
+require './lib/loader'
 
 class App < Sinatra::Base
   register Sinatra::SensibleLogging

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,0 +1,8 @@
+require 'sequel'
+require 'sensible_logging'
+require 'sinatra/base'
+require 'sinatra/json'
+require 'logger'
+require 'require_all'
+
+require_all 'lib'


### PR DESCRIPTION
We're making some changes to this API to update the last login value
when someone authenticates.

In order to do this we need a Sequel model, which is going to require
some files in lib.  It makes sense at this point to require all from
lib.