### PR TITLE
Introduce a user model for the Sequel gem

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -5,4 +5,12 @@ require 'sinatra/json'
 require 'logger'
 require 'require_all'
 
+DB = Sequel.connect(
+  adapter: 'mysql2',
+  host: ENV.fetch('DB_HOSTNAME'),
+  database: ENV.fetch('DB_NAME'),
+  user: ENV.fetch('DB_USER'),
+  password: ENV.fetch('DB_PASS')
+)
+
 require_all 'lib'

--- a/lib/user.rb
+++ b/lib/user.rb
@@ -1,0 +1,3 @@
+class User < Sequel::Model(:userdetails)
+  User.unrestrict_primary_key
+end


### PR DESCRIPTION
We keep track of last_login to effectively identify inactive users.
This used to be done by the logging API but will now be done by this
API.

This makes it easier to split the userdetails table out of the main
database and be owned by this API.

The definition of "last login" will change as a result of this, and will
effectively be "last login attempt" as we will populate this field for
both access accept and access reject.  I don't see this affecting GDPR
cleanup tasks at all.