### PR TITLE
Don't record last login for HEALTH user

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -30,20 +30,12 @@ class App < Sinatra::Base
 private
 
   def authorize_user(user_name)
-    user = user_from_db(user_name)
+    user = User.find(username: user_name)
+
     return 404 unless user
 
-    touch_last_login(user)
+    user.update(last_login: Time.now) unless user_name == 'HEALTH'
 
     json "control:Cleartext-Password": user.password
-  end
-
-  def user_from_db(user_name)
-    User.find(username: user_name)
-  end
-
-  def touch_last_login(user)
-    user.last_login = Time.now
-    user.save
   end
 end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -26,6 +26,11 @@ describe App do
       it 'responds with password in the body' do
         expect(last_response.body).to eq('{"control:Cleartext-Password":"TestUserPassword"}')
       end
+
+      it 'does not update the last_login' do
+        user = User.find(username: 'HEALTH')
+        expect(user.last_login).to be_nil
+      end
     end
 
     context 'as a non-existent user' do


### PR DESCRIPTION
Preserve this functionality from the logging API.

The health user is exempt from GDPR cleanup, so recording
last_login is not required. Also health checks happen frequently and
will just be unnecessary strain on the database.