### PR TITLE
only bind ports in development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,13 @@ ifdef DEPLOYMENT
 	BUNDLE_FLAGS = --build-arg BUNDLE_INSTALL_CMD='bundle install --without test'
 endif
 
-DOCKER_BUILD_CMD = docker-compose build $(BUNDLE_FLAGS)
+DOCKER_COMPOSE = docker-compose -f docker-compose.yml
+ifndef JENKINS_URL
+  DOCKER_COMPOSE += -f docker-compose.development.yml
+endif
+
+
+DOCKER_BUILD_CMD = $(DOCKER_COMPOSE) build $(BUNDLE_FLAGS)
 
 
 build:
@@ -13,21 +19,21 @@ build:
 
 serve:
 	$(MAKE) build
-	docker-compose up -d db
+	$(DOCKER_COMPOSE) up -d db
 	./mysql/bin/wait_for_mysql
-	docker-compose up -d
+	$(DOCKER_COMPOSE) up -d
 
 lint:
 	$(MAKE) build
-	docker-compose run --rm app bundle exec govuk-lint-ruby
+	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-ruby
 
 test:
 	$(MAKE) serve
-	docker-compose run --rm app rspec
+	$(DOCKER_COMPOSE) run --rm app rspec
 	$(MAKE) stop
 
 stop:
-	docker-compose kill
-	docker-compose rm -f
+	$(DOCKER_COMPOSE) kill
+	$(DOCKER_COMPOSE) rm -f
 
 .PHONY: test serve stop lint

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -1,0 +1,6 @@
+version: '3.4'
+
+services:
+  app:
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: govwifi_test
-    ports:
-      - "13306:3306"
+    expose:
+      - "3306"
 
   app:
     build: .
@@ -19,5 +19,5 @@ services:
       RACK_ENV: development
     links:
       - db
-    ports:
-      - "8080:8080"
+    expose:
+      - "8080"


### PR DESCRIPTION
We only want to bind ports while in development, to avoid doing it for in jenkins.

This will allow us to run the tests in parallel