### PR TITLE
Run acceptance specs when a merge to master occurs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,18 @@ pipeline {
           sh 'make stop'
         }
       }
+    }
 
+
+    stage('Acceptance Tests') {
+      agent none
+      when {
+        branch 'master'
+        beforeAgent true
+      }
+      steps {
+        build 'govwifi-acceptance-tests/master'
+      }
     }
 
     stage('Publish stable tag') {


### PR DESCRIPTION
- When there is a merge to `auth-api/master` it triggers the `acceptance-tests/master` pipeline to be built.
- This runs the acceptance tests on all the dependent master branches.
- If it fails it blocks the deploy, but not the merge.

Exists in the `frontend` already here: https://github.com/alphagov/govwifi-frontend/blob/master/Jenkinsfile#L33