### PR TITLE
Revert "increase the database connection count to 16"

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -10,8 +10,7 @@ DB = Sequel.connect(
   host: ENV.fetch('DB_HOSTNAME'),
   database: ENV.fetch('DB_NAME'),
   user: ENV.fetch('DB_USER'),
-  password: ENV.fetch('DB_PASS'),
-  max_connections: 16,
+  password: ENV.fetch('DB_PASS')
 )
 
 require_all 'lib'


### PR DESCRIPTION
Whilst this has been tested in staging, we've opted to deploy this change out to the Logging API first, which is not on the critical path.

This PR is expected to be reverted after the Logging API change has been tested in production