### PR TITLE
Increase the database connection count to 16

### DIFF
--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -10,7 +10,8 @@ DB = Sequel.connect(
   host: ENV.fetch('DB_HOSTNAME'),
   database: ENV.fetch('DB_NAME'),
   user: ENV.fetch('DB_USER'),
-  password: ENV.fetch('DB_PASS')
+  password: ENV.fetch('DB_PASS'),
+  max_connections: 16,
 )
 
 require_all 'lib'


### PR DESCRIPTION
We've been running out of connections when under load, so increase the [pool size from 4][2].

This takes us from 12 connections to 48 connections per regional db\*, which is well within our limits\*\*.

16 has been chosen so we can have a DB connection [per thread][1]. Given that this service
is a thin wrapper around the database, the requests will immediately wait. Aligning thread
count with the connection pool size should avoid this issue.

\*: connection count is based on pool size per instance, 3 instances per region
\*\*: limit per db is based on memory size of db. Ours has 4gb, and as defined by the parameter group, is `{DBInstanceClassMemory/12582880}`, which is `(4096*1024*1024)/12582880` which is 341 max connections.

[1]: https://github.com/puma/puma/blob/821905c84587c9f403ebe26bba15e01dab5148cb/examples/config.rb#L65
[2]: https://github.com/jeremyevans/sequel/blob/master/doc/opening_databases.rdoc#general-connection-options