### PR TITLE
change to using mysql 8

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,3 +1,5 @@
-FROM mysql:5.7
+FROM mysql:8.0
 
 ADD schema.sql /docker-entrypoint-initdb.d
+
+CMD [ "--default-authentication-plugin=mysql_native_password" ]


### PR DESCRIPTION
We need to use mysql_native_password, as mariadb client doesn't ship with this yet