### PR TITLE
Use `rubocop-govuk` for linting instead of `govuk-lint`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
+inherit_mode:
+  merge:
+    - Exclude

--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ gem 'sinatra'
 gem 'sinatra-contrib'
 
 group :test do
-  gem 'govuk-lint'
   gem 'rack-test'
   gem 'rspec'
+  gem 'rubocop-govuk'
   gem 'simplecov', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,18 @@
-source 'http://rubygems.org'
-ruby File.read('.ruby-version').chomp
+source "http://rubygems.org"
+ruby File.read(".ruby-version").chomp
 
-gem 'mysql2'
-gem 'puma'
-gem 'require_all'
-gem 'sensible_logging', '~> 0.4.1'
-gem 'sentry-raven'
-gem 'sequel', '~> 5.22'
-gem 'sinatra'
-gem 'sinatra-contrib'
+gem "mysql2"
+gem "puma"
+gem "require_all"
+gem "sensible_logging", "~> 0.4.1"
+gem "sentry-raven"
+gem "sequel", "~> 5.22"
+gem "sinatra"
+gem "sinatra-contrib"
 
 group :test do
-  gem 'rack-test'
-  gem 'rspec'
-  gem 'rubocop-govuk'
-  gem 'simplecov', require: false
+  gem "rack-test"
+  gem "rspec"
+  gem "rubocop-govuk"
+  gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,15 +13,9 @@ GEM
     docile (1.3.2)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.11.1)
-    govuk-lint (3.11.5)
-      rubocop (~> 0.72)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     json (2.2.0)
     minitest (5.11.3)
     multi_json (1.13.1)
@@ -29,8 +23,8 @@ GEM
     mustermann (1.0.3)
     mysql2 (0.5.1)
     nio4r (2.5.2)
-    parallel (1.17.0)
-    parser (2.6.3.0)
+    parallel (1.19.1)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
     puma (4.3.1)
       nio4r (~> 2.0)
@@ -40,11 +34,8 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
-    rake (12.3.3)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     require_all (2.0.0)
+    rexml (3.2.4)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -58,27 +49,28 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.72.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.6)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.2.0)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-govuk (3.6.0)
+      rubocop (= 0.82.0)
+      rubocop-rails (~> 2)
+      rubocop-rake (~> 0.5.1)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.5.2)
+      activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.33.0)
-      rubocop (>= 0.60.0)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (1.38.1)
+      rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.58.0)
-      rake (>= 0.9, < 13)
-      sass (~> 3.5, >= 3.5.5)
     sensible_logging (0.4.1)
       activesupport (~> 5.2)
       rack (~> 2.0)
@@ -106,18 +98,18 @@ GEM
     tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.0)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  govuk-lint
   mysql2
   puma
   rack-test
   require_all
   rspec
+  rubocop-govuk
   sensible_logging (~> 0.4.1)
   sentry-raven
   sequel (~> 5.22)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ serve:
 
 lint:
 	$(MAKE) build
-	$(DOCKER_COMPOSE) run --rm app bundle exec govuk-lint-ruby
+	$(DOCKER_COMPOSE) run --rm app bundle exec rubocop
 
 test:
 	$(MAKE) serve

--- a/app.rb
+++ b/app.rb
@@ -1,4 +1,4 @@
-require './lib/loader'
+require "./lib/loader"
 
 class App < Sinatra::Base
   register Sinatra::SensibleLogging
@@ -19,12 +19,12 @@ class App < Sinatra::Base
     set :dump_errors, false
   end
 
-  get '/authorize/user/:user_name' do
-    authorize_user(params['user_name'])
+  get "/authorize/user/:user_name" do
+    authorize_user(params["user_name"])
   end
 
-  get '/authorize/user/:user_name/*' do
-    authorize_user(params['user_name'])
+  get "/authorize/user/:user_name/*" do
+    authorize_user(params["user_name"])
   end
 
 private

--- a/app.rb
+++ b/app.rb
@@ -3,9 +3,7 @@ require "./lib/loader"
 class App < Sinatra::Base
   register Sinatra::SensibleLogging
 
-  sensible_logging(
-    logger: Logger.new(STDOUT)
-  )
+  sensible_logging(logger: Logger.new(STDOUT))
 
   configure do
     set :log_level, Logger::DEBUG

--- a/lib/loader.rb
+++ b/lib/loader.rb
@@ -1,17 +1,17 @@
-require 'sequel'
-require 'sensible_logging'
-require 'sinatra/base'
-require 'sinatra/json'
-require 'logger'
-require 'require_all'
+require "sequel"
+require "sensible_logging"
+require "sinatra/base"
+require "sinatra/json"
+require "logger"
+require "require_all"
 
 DB = Sequel.connect(
-  adapter: 'mysql2',
-  host: ENV.fetch('DB_HOSTNAME'),
-  database: ENV.fetch('DB_NAME'),
-  user: ENV.fetch('DB_USER'),
-  password: ENV.fetch('DB_PASS'),
+  adapter: "mysql2",
+  host: ENV.fetch("DB_HOSTNAME"),
+  database: ENV.fetch("DB_NAME"),
+  user: ENV.fetch("DB_USER"),
+  password: ENV.fetch("DB_PASS"),
   max_connections: 16,
 )
 
-require_all 'lib'
+require_all "lib"

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -1,81 +1,81 @@
 describe App do
-  describe 'visiting /authorize' do
-    let(:username) { 'abcdef' }
-    let(:client_mac) { 'ee-ee-ee-ee-ee' }
-    let(:ap_mac) { 'ff-ff-ff-ff-ff' }
-    let(:ap_ip_address) { '192.168.1.100' }
-    let(:ap_aruba_name) { 'hallway-1' }
-    let(:ap_meraki_name) { 'hallway-2' }
+  describe "visiting /authorize" do
+    let(:username) { "abcdef" }
+    let(:client_mac) { "ee-ee-ee-ee-ee" }
+    let(:ap_mac) { "ff-ff-ff-ff-ff" }
+    let(:ap_ip_address) { "192.168.1.100" }
+    let(:ap_aruba_name) { "hallway-1" }
+    let(:ap_meraki_name) { "hallway-2" }
 
     after do
       DB[:userdetails].truncate
     end
 
-    context 'as the Health user' do
-      let(:username) { 'HEALTH' }
+    context "as the Health user" do
+      let(:username) { "HEALTH" }
 
       before do
-        DB[:userdetails].insert(username: username, password: 'TestUserPassword')
+        DB[:userdetails].insert(username: username, password: "TestUserPassword")
         get "/authorize/user/#{username}"
       end
 
-      it 'responds with 200 to a GET' do
+      it "responds with 200 to a GET" do
         expect(last_response).to be_ok
       end
 
-      it 'responds with password in the body' do
+      it "responds with password in the body" do
         expect(last_response.body).to eq('{"control:Cleartext-Password":"TestUserPassword"}')
       end
     end
 
-    context 'as a non-existent user' do
-      before { get '/authorize/user/not-a-user' }
+    context "as a non-existent user" do
+      before { get "/authorize/user/not-a-user" }
 
-      it 'responds with 404 to a GET' do
+      it "responds with 404 to a GET" do
         expect(last_response.status).to eq(404)
       end
 
-      it 'responds with an empty string' do
-        expect(last_response.body).to eq('')
+      it "responds with an empty string" do
+        expect(last_response.body).to eq("")
       end
     end
 
-    context 'with extra url parameters' do
+    context "with extra url parameters" do
       let(:url) { "/authorize/user/#{username}/mac/#{client_mac}/ap/#{ap_mac}/site/#{ap_ip_address}/apg/#{ap_aruba_name}/mdn/#{ap_meraki_name}" }
 
-      context 'as a valid user' do
+      context "as a valid user" do
         before do
-          DB[:userdetails].insert(username: username, password: 'FooBarBaz')
+          DB[:userdetails].insert(username: username, password: "FooBarBaz")
           get url
         end
 
-        it 'responds with password in the body' do
+        it "responds with password in the body" do
           expect(last_response.body).to eq('{"control:Cleartext-Password":"FooBarBaz"}')
         end
       end
 
-      context 'as an invalid user' do
-        let(:username) { 'invalid-user' }
+      context "as an invalid user" do
+        let(:username) { "invalid-user" }
         before { get url }
 
-        it 'responds with an empty string' do
-          expect(last_response.body).to eq('')
+        it "responds with an empty string" do
+          expect(last_response.body).to eq("")
         end
       end
     end
 
-    context 'with multiple connections to mysql' do
+    context "with multiple connections to mysql" do
       let(:url) { "/authorize/user/#{username}" }
 
       before do
-        DB[:userdetails].insert(username: username, password: 'FooBarBaz')
+        DB[:userdetails].insert(username: username, password: "FooBarBaz")
 
         200.times do
           get url
         end
       end
 
-      it 'does not fall over' do
+      it "does not fall over" do
         expect(last_response).to be_ok
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-require 'rack/test'
-require 'rspec'
-require 'simplecov'
+require "rack/test"
+require "rspec"
+require "simplecov"
 
-ENV['RACK_ENV'] = 'test'
+ENV["RACK_ENV"] = "test"
 
-require File.expand_path '../app.rb', __dir__
+require File.expand_path "../app.rb", __dir__
 
 module RSpecMixin
   include Rack::Test::Methods


### PR DESCRIPTION
- The `govuk-lint` gem is [deprecated](https://github.com/alphagov/govuk-lint/commit/8ef29badd90a1936774657bc89f3a4cb77210e5f)!
- This switches to `rubocop-govuk`, the more up-to-date replacement, using the [migration guide](https://docs.publishing.service.gov.uk/manual/migrate-from-govuk-lint.html).
- Thanks for adopting our linting rules!
- Closes #126.