### PR TITLE
Manually bump the rexml version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     rainbow (3.0.0)
     regexp_parser (1.8.2)
     require_all (3.0.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)


### PR DESCRIPTION
### What

Bump the `rexml` version because our current version contains security vulnerabilities: 

```
Vulnerable versions: < 3.2.5
Patched version: 3.2.5
The REXML gem before 3.2.5 in Ruby before 2.6.7, 2.7.x before 2.7.3, and 3.x before 3.0.1 does not properly address XML round-trip issues. An incorrect document can be produced after parsing and serializing.
```

### Why

Dependabot is failing to make the change and open a PR in Github.