### PR TITLE
Revert "Bump puma from 5.3.2 to 5.4.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     parallel (1.19.2)
     parser (2.7.2.0)
       ast (~> 2.4.1)
-    puma (5.4.0)
+    puma (5.3.2)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-protection (2.1.0)


### PR DESCRIPTION
Reverts alphagov/govwifi-authentication-api#234