### PR TITLE
Update pr.yml configuration

### DIFF
--- a/ci/pipelines/pr.yml
+++ b/ci/pipelines/pr.yml
@@ -15,11 +15,6 @@ resource_types:
     password: ((docker_hub_authtoken))
 
 resources:
-  - name: tech-ops
-    type: git
-    source:
-      uri: https://github.com/alphagov/tech-ops.git
-
   - name: govwifi-authentication-api
     type: git
     source:
@@ -91,19 +86,10 @@ jobs:
   - name: self-update
     serial: true
     plan:
-    - get: tech-ops
-      params:
-        submodules: none
     - get: govwifi-authentication-api
       trigger: true
-    - task: set-pipelines
-      file: tech-ops/ci/tasks/self-updating-pipeline.yaml
-      input_mapping: {repository: govwifi-authentication-api}
-      params:
-        CONCOURSE_TEAM: govwifi
-        CONCOURSE_PASSWORD: ((readonly_local_user_password))
-        PIPELINE_PATH: ci/pipelines/pr.yml
-        PIPELINE_NAME: authentication-api-pr
+    - set_pipeline: authentication-api-pr
+      file: govwifi-authentication-api/ci/pipelines/pr.yml
 
   - name: lint & test
     interruptible: true


### PR DESCRIPTION
### What

Remove references to `tech-ops` repo and use `set_pipeline` command instead of `set-pipelines` task.

### Why

* We no longer need to point to tech-ops since we're creating our own GovWifi Concourse.
* `set_pipeline` is the built in functionality from Concourse, the alternative approach we were using was deprecated.