### PR TITLE
Add GitHub action to lint and test our code

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,31 @@
+name: authentication-api lint and test
+on:
+  push:
+    branches:
+      - add-github-action
+  pull_request:
+    branches:
+      - add-github-action
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+      - name: Run lint
+        run: make lint
+
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0.3
+      - name: Run tests
+        run: make test

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,10 +2,10 @@ name: authentication-api lint and test
 on:
   push:
     branches:
-      - add-github-action
+      - master
   pull_request:
     branches:
-      - add-github-action
+      - master
 
 jobs:
   lint:


### PR DESCRIPTION
### What
Add Github workflow to lint and test our code.


### Why
We are migrating our PR pipelines away from Concourse into Github Actions.

Link to Trello card (if applicable): https://trello.com/c/TnxuCVW9/2017-concourse-migration-migrate-linting-pipelines-to-github-actions[](https://github.com/camdesgov)