### PR TITLE
Change ECS service name in staging

### DIFF
--- a/ci/tasks/scripts/deploy.sh
+++ b/ci/tasks/scripts/deploy.sh
@@ -9,7 +9,13 @@ function deploy() {
 
   deploy_stage="$(stage_name)"
   cluster_name="${deploy_stage}-${CLUSTER_NAME}"
-  service_name="${SERVICE_NAME}-${deploy_stage}"
+
+	if [[ deploy_stage == "staging" ]]
+	then
+		service_name="authentication-api-service-${deploy_stage}"
+	else
+		service_name="${SERVICE_NAME}-${deploy_stage}"
+	fi
 
   ecs_deploy_region \
     "${cluster_name}" \


### PR DESCRIPTION
### What
We are in the process of making any references to the authentication api infrastructure consistent, and we are testing this change in Staging. 

### Why
At present we are using the name "authentication-api" and "authorization-api" to refer to the same things, which is confusing. This change is part of rectifying that.

Link to Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-204