### PR TITLE
Change ECS service name for entire deploy process

### DIFF
--- a/ci/tasks/deploy.yml
+++ b/ci/tasks/deploy.yml
@@ -8,7 +8,7 @@ params:
   AWS_SECRET_ACCESS_KEY:
 
   # These are set for deploy.sh
-  SERVICE_NAME: "authorisation-api-service"
+  SERVICE_NAME: "authentication-api-service"
   CLUSTER_NAME: "api-cluster"
 
 inputs:

--- a/ci/tasks/scripts/deploy.sh
+++ b/ci/tasks/scripts/deploy.sh
@@ -9,13 +9,7 @@ function deploy() {
 
   deploy_stage="$(stage_name)"
   cluster_name="${deploy_stage}-${CLUSTER_NAME}"
-
-	if [[ deploy_stage == "staging" ]]
-	then
-		service_name="authentication-api-service-${deploy_stage}"
-	else
-		service_name="${SERVICE_NAME}-${deploy_stage}"
-	fi
+	service_name="${SERVICE_NAME}-${deploy_stage}"
 
   ecs_deploy_region \
     "${cluster_name}" \


### PR DESCRIPTION
### What
We are in the process of making any references to the authentication api infrastructure consistent.

### Why
At present we are using the name "authentication-api" and "authorization-api" to refer to the same things, which is confusing. This change is part of rectifying that.

Link to Jira card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-204
