### PR TITLE
Introduce an AWS Codebuild task

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,27 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - echo "AWS_REGION is $AWS_REGION "
+      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/$STAGE/authentication-api
+      - echo "REPOSITORY_URI is $REPOSITORY_URI"
+      - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG="latest"
+      - echo "$DOCKER_HUB_AUTHTOKEN_ENV" | docker login -u $(echo $DOCKER_HUB_USERNAME_ENV) --password-stdin
+  build:
+    commands:
+      - echo Build started on `date`
+      - BUNDLE_INSTALL_CMD="bundle install --jobs 20 --retry 5"
+      - echo Building the Docker image...
+      - docker build --build-arg BUNDLE_INSTALL_CMD='bundle install --jobs 20 --retry 5' -t $REPOSITORY_URI:$IMAGE_TAG .
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo Writing image definitions file...
+      - printf '[{"name":"authentication-api","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json


### PR DESCRIPTION
### What
Introduce an AWS Codebuild task permitting us to migrate from concourse to AWS Developer Tools

### Why
We need to migrate away from Concourse due to strategic decision to use managed services.


### Jira card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-253