### PR TITLE
Revert "Add a no op line to test pipeline triggering"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # GovWifi Authentication API
-# TEST
 
 This API is used by the frontend when a connection request is made to GovWifi.
 Its function is to check these requests against user details and the result determines how FreeRADIUS reacts to it e.g. allow / dissallow the connection.


### PR DESCRIPTION
Reverts alphagov/govwifi-authentication-api#303

### Why
This PR was a no-op used solely to test a pipeline. The test was successful and so this should be reverted.