### PR TITLE
Add separate staging and production ECR repos

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,7 +6,7 @@ phases:
       - echo Logging in to Amazon ECR...
       - aws --version
       - echo "AWS_REGION is $AWS_REGION "
-      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/authentication-api
+      - REPOSITORY_URI=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/govwifi/authentication-api/$STAGE
       - echo "REPOSITORY_URI is $REPOSITORY_URI"
       - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)


### PR DESCRIPTION
### What
Add separate staging and production ECR repos

### Why
So code releases can be tested thoroughly before they are released to production.

Link to Trello card (if applicable): 
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-642