### PR TITLE
Fix Test and Lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifdef DEPLOYMENT
 	BUNDLE_FLAGS = --build-arg BUNDLE_INSTALL_CMD='bundle install --without test'
 endif
 
-DOCKER_COMPOSE = docker-compose -f docker-compose.yml
+DOCKER_COMPOSE = docker compose -f docker-compose.yml
 
 ifdef ON_CONCOURSE
   DOCKER_COMPOSE += -f docker-compose.concourse.yml

--- a/mysql/bin/wait_for_mysql
+++ b/mysql/bin/wait_for_mysql
@@ -3,7 +3,7 @@
 # The Jenkins runner doesn't support TTY sessions meaning docker-compose exec commands
 # failed to execute properly and would hang the CI
 # https://github.com/docker/compose/issues/5696
-until docker-compose exec -T db mysql -hdb -uroot -proot -e 'SELECT 1' &> /dev/null
+until docker compose exec -T db mysql -hdb -uroot -proot -e 'SELECT 1' &> /dev/null
 do
   printf "."
   sleep 1


### PR DESCRIPTION
### What
Fix Test and Lint

### Why
Docker compose command with dash is now deprecated. Fixing.

