### PR TITLE
Revert "chore(deps): Bump sequel from 5.92.0 to 5.95.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     sentry-ruby (5.26.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    sequel (5.95.1)
+    sequel (5.92.0)
       bigdecimal
     simplecov (0.22.0)
       docile (~> 1.1)


### PR DESCRIPTION
Reverts GovWifi/govwifi-authentication-api#478