### PR TITLE
GW-2784 update ruby git action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+  # ignore all ruby updates, this is handled by the ruby_updater workflow
   ignore:
   - dependency-name: ruby
-    versions:
-    - 3.0.0.pre.alpine

--- a/.github/workflows/ruby-updater.yml
+++ b/.github/workflows/ruby-updater.yml
@@ -31,7 +31,7 @@ jobs:
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-version-check@main
       with:
         major-version: ${{ env.MAJOR_VERSION }}
-      ## This step will check the current Ruby version against the latest available version for the specified major version. It will set outputs TARGET_RUBY_VERSION, NEW_RUBY, and RUBY_PATHS.
+        ## This step will check the current Ruby version against the latest available version for the specified major version. It will set outputs TARGET_RUBY_VERSION, NEW_RUBY, and RUBY_PATHS.
 
     - name: Setup github branch for Ruby Updates
       id: setup-branch
@@ -57,19 +57,19 @@ jobs:
 
     - name: Update Ruby Version
       env:
-         TARGET_RUBY_VERSION: ${{ needs.check-ruby-setup.outputs.TARGET_RUBY_VERSION }}
-         COMMIT_BRANCH: ${{ needs.check-ruby-setup.outputs.COMMIT_BRANCH }}
-         NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
-         RUBY_PATHS: ${{ needs.check-ruby-setup.outputs.RUBY_PATHS}}
+        TARGET_RUBY_VERSION: ${{ needs.check-ruby-setup.outputs.TARGET_RUBY_VERSION }}
+        COMMIT_BRANCH: ${{ needs.check-ruby-setup.outputs.COMMIT_BRANCH }}
+        NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
+        RUBY_PATHS: ${{ needs.check-ruby-setup.outputs.RUBY_PATHS}}
       ## Only update if the Ruby Version has changed.
       if: ${{ env.NEW_RUBY == 'true' }}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-updater-multi-env@main
 
     - name: Commit and Raise PR
       env:
-         TARGET_RUBY_VERSION: ${{ needs.check-ruby-setup.outputs.TARGET_RUBY_VERSION }}
-         COMMIT_BRANCH: ${{ needs.check-ruby-setup.outputs.COMMIT_BRANCH }}
-         NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
+        TARGET_RUBY_VERSION: ${{ needs.check-ruby-setup.outputs.TARGET_RUBY_VERSION }}
+        COMMIT_BRANCH: ${{ needs.check-ruby-setup.outputs.COMMIT_BRANCH }}
+        NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-commit-changes@main
       ## Only update if the Ruby Version has changed.
       if: ${{ env.NEW_RUBY == 'true' }}

--- a/.github/workflows/ruby-updater.yml
+++ b/.github/workflows/ruby-updater.yml
@@ -3,16 +3,17 @@ name: Upgrade Ruby
 on:
   workflow_dispatch:
   schedule:
-    - cron: "5 0 15 * 0" # Runs monthly (in the middle to avoid any date clashes)
+    - cron: "5 0 15 * *" # Runs monthly (in the middle to avoid any date clashes)
 
-permissions:
-  contents: write
-  pull-requests: write
+env:
+  MAIN_BRANCH: 'master'
+  MAJOR_VERSION: '3'
 
 jobs:
-
   check-ruby-setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       TARGET_RUBY_VERSION: ${{ steps.check-ruby.outputs.TARGET_RUBY_VERSION }}
       NEW_RUBY: ${{ steps.check-ruby.outputs.NEW_RUBY }}
@@ -21,14 +22,20 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check Ruby Version
       id: check-ruby
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-version-check@main
+      with:
+        major-version: ${{ env.MAJOR_VERSION }}
+      ## This step will check the current Ruby version against the latest available version for the specified major version. It will set outputs TARGET_RUBY_VERSION, NEW_RUBY, and RUBY_PATHS.
 
     - name: Setup github branch for Ruby Updates
       id: setup-branch
+      ## Only run if the Ruby Version has changed.
       if: ${{ steps.check-ruby.outputs.NEW_RUBY == 'true' }}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-setup-branch@main
       env:
@@ -36,20 +43,26 @@ jobs:
 
   upgrade-ruby:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
     needs: [check-ruby-setup]
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Update Ruby Version
       env:
-        TARGET_RUBY_VERSION: ${{ needs.check-ruby-setup.outputs.TARGET_RUBY_VERSION }}
-        COMMIT_BRANCH: ${{ needs.check-ruby-setup.outputs.COMMIT_BRANCH }}
-        NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
-        RUBY_PATHS: ${{ needs.check-ruby-setup.outputs.RUBY_PATHS}}
+         TARGET_RUBY_VERSION: ${{ needs.check-ruby-setup.outputs.TARGET_RUBY_VERSION }}
+         COMMIT_BRANCH: ${{ needs.check-ruby-setup.outputs.COMMIT_BRANCH }}
+         NEW_RUBY: ${{ needs.check-ruby-setup.outputs.NEW_RUBY}}
+         RUBY_PATHS: ${{ needs.check-ruby-setup.outputs.RUBY_PATHS}}
       ## Only update if the Ruby Version has changed.
-      if: ${{ env.NEW_RUBY  == 'true' }}
+      if: ${{ env.NEW_RUBY == 'true' }}
       uses: govwifi/shared-actions-workflows/.github/actions/ruby-updater-multi-env@main
 
     - name: Commit and Raise PR
@@ -62,4 +75,4 @@ jobs:
       if: ${{ env.NEW_RUBY == 'true' }}
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        main-branch: master
+        main-branch: ${{ env.MAIN_BRANCH }}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,13 +11,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run lint
         run: make lint
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: make test


### PR DESCRIPTION
### What

Update Ruby updater workflow to narrow permissions

### Why

Akido Security audit 

Link to JIRA card (if applicable):
[GW-2784](https://technologyprogramme.atlassian.net/browse/GW-2784)

